### PR TITLE
Provide a way to avoid data-react-* properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,14 @@ module.exports = SomePage;
 
 #### `render(options)`
 
-option       | values                                                      | default
--------------|-------------------------------------------------------------|---------
-`template`   | [Lo-Dash template](http://lodash.com/docs#template) string or filename | `null`
-`harmony`    | `true`: enable ES6 features                                 | `true`
-`stripTypes` | `true`: enable [Flow](http://flowtype.org) type annotations | `true`
-`hyphenate`  | `true`: SomePage.jsx -> some-page.html                      | `true`
-`data     `  | E.g. `{title: 'Hello'}` or `function(file) { ... }`         | `object` or `function`
+option         | values                                                                 | default
+---------------|------------------------------------------------------------------------|--------
+`template`     | [Lo-Dash template](http://lodash.com/docs#template) string or filename | `null`
+`harmony`      | `true`: enable ES6 features                                            | `true`
+`stripTypes`   | `true`: enable [Flow](http://flowtype.org) type annotations            | `true`
+`hyphenate`    | `true`: SomePage.jsx -> some-page.html                                 | `true`
+`staticMarkup` | `true`: HTML output will not have `data-react-*` attributes            | `false`
+`data     `    | E.g. `{title: 'Hello'}` or `function(file) { ... }`                    | `object` or `function`
 
 ## Related Projects
 

--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ function Plugin(options) {
           m.paths = module.paths.slice(1);
           m._compile(contents, file.path);
           var Component = m.exports;
-          var markup = options.toStatic ? renderToStaticMarkup(Component) : renderToString(Component);
+          var markup = options.staticMarkup ? renderToStaticMarkup(Component) : renderToString(Component);
 
           if (options.template) {
             var data = _.extend({}, (typeof(options.data) == 'function' ? options.data(file) : options.data));

--- a/index.js
+++ b/index.js
@@ -46,6 +46,14 @@ function renderToString(page) {
   return React.renderToString(React.createElement(page, props, child));
 }
 
+/**
+ * Just produce static markup without data-react-* attributes
+ * http://facebook.github.io/react/docs/top-level-api.html#react.rendertostaticmarkup
+ */
+function renderToStaticMarkup(page) {
+  return React.renderToStaticMarkup(React.createElement(page));
+}
+
 // Plugin level function (dealing with files)
 function Plugin(options) {
 
@@ -98,7 +106,7 @@ function Plugin(options) {
           m.paths = module.paths.slice(1);
           m._compile(contents, file.path);
           var Component = m.exports;
-          var markup = renderToString(Component);
+          var markup = options.toStatic ? renderToStaticMarkup(Component) : renderToString(Component);
 
           if (options.template) {
             var data = _.extend({}, (typeof(options.data) == 'function' ? options.data(file) : options.data));

--- a/test.js
+++ b/test.js
@@ -66,6 +66,32 @@ it('Should render a simple React component with a template', function(cb) {
 
 });
 
+it('Should render a simple React component as static markup', function(cb) {
+
+  var stream = render({
+    staticMarkup: true
+  });
+
+  stream.on('data', function(file) {
+    var contents = file.contents.toString('utf8');
+    assert(contents.indexOf('data-react') === -1);
+    cb();
+  });
+
+  stream.write(new gutil.File({
+    path: 'SampleComponent.jsx',
+    cwd: __dirname,
+    contents: new Buffer(
+      'var React = require("./node_modules/react"); ' +
+      'var HelloMessage = React.createClass({' +
+      '  render: function() {return React.DOM.div(null, "Hello world!");}' +
+      '}); '+
+      'module.exports = HelloMessage;'
+    )
+  }));
+
+});
+
 it('Should render a simple React component with a template and data function', function(cb) {
 
   var stream = render({


### PR DESCRIPTION
Hi @koistya 

I happened to need _gulp-render_ to provide html without the `data-react-*` attributes, so I've added a way to send the content through `React.renderToStaticMarkup` instead of `React.renderToString`.

A user would set `toStatic: true` when configuring the plugin.

I'd be interested to get your thoughts on the appropriateness of this option.
